### PR TITLE
Fix config dependency handling

### DIFF
--- a/README_ExecCheck.md
+++ b/README_ExecCheck.md
@@ -52,6 +52,16 @@ macOS does not allow live access to the ExecPolicy DB while it is in use by `sys
 
 ---
 
+## Installation
+
+Ensure Python 3 is available and install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
 ## ✨ Features
 
 ### ✔️ Risk-Based Scoring

--- a/execcheck/config.py
+++ b/execcheck/config.py
@@ -1,6 +1,13 @@
 from pydantic import BaseModel, Field
-import yaml
 from typing import Optional
+
+try:
+    import yaml
+except ImportError as exc:
+    raise ImportError(
+        "PyYAML is required for loading configuration files. "
+        "Install it with 'pip install pyyaml'."
+    ) from exc
 
 class ScoringWeights(BaseModel):
     unsigned: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pyyaml
+requests
+rich
+pydantic


### PR DESCRIPTION
## Summary
- document installation steps
- gracefully handle missing PyYAML dependency
- specify Python package requirements

## Testing
- `python3 -m py_compile execcheck/*.py execcheck/utils/*.py`
- `python3 - <<'PY'
try:
    from execcheck.config import load_config
except Exception as e:
    print('error', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68796a9938048327bb308bce8f8f30fb