### PR TITLE
Remove filter examples from ExecCheck docs

### DIFF
--- a/README_ExecCheck.md
+++ b/README_ExecCheck.md
@@ -103,22 +103,6 @@ ExecCheck supports:
 --output-format [table|csv|json|ndjson]
 ```
 
-### ✔️ Filtering
-
-Filter records using:
-
-```bash
---filter risk_score ">=25"
---filter is_signed false
---filter team_identifier !apple
---filter bundle_id .lulu.
-```
-
-- Case-insensitive
-- Supports numeric comparisons
-- Supports substring or negation
-
----
 
 ## 🔄 Automate Your Workflow
 
@@ -128,7 +112,6 @@ You can integrate ExecCheck into your triage pipeline:
 python3 -m execcheck \
   --db ./ExecPolicy \
   --config sample_config.yaml \
-  --filter risk_score ">=25" \
   --ioc ./ioc_hits.txt \
   --only-ioc-matches \
   --output-format ndjson \


### PR DESCRIPTION
## Summary
- drop the `--filter` documentation section
- remove the `--filter` usage example

## Testing
- `python -m execcheck --help` *(fails: ModuleNotFoundError: No module named 'rich')*
- `pip install rich` *(fails: Could not find a version that satisfies the requirement rich)*

------
https://chatgpt.com/codex/tasks/task_e_68796d32693c832782ecfead4fac3ec1