### PR TITLE
Improve documentation and testing

### DIFF
--- a/execcheck/__init__.py
+++ b/execcheck/__init__.py
@@ -1,0 +1,3 @@
+"""ExecCheck: macOS ExecPolicy analysis utilities."""
+
+__all__ = []

--- a/execcheck/__main__.py
+++ b/execcheck/__main__.py
@@ -1,3 +1,5 @@
+"""Executable entry point for ``python -m execcheck``."""
+
 from .cli import main
 
 if __name__ == "__main__":

--- a/execcheck/cli.py
+++ b/execcheck/cli.py
@@ -1,3 +1,5 @@
+"""Command-line interface for running ExecCheck."""
+
 import argparse
 from .combine import combine_exec_policy_tables
 from .scorer import score_entry
@@ -11,7 +13,10 @@ from .translate import (
 )
 from .utils.time import to_iso8601
 
-def load_iocs(path):
+
+def load_iocs(path: str) -> set[str]:
+    """Load indicators of compromise from ``path``."""
+
     iocs = set()
     with open(path, "r") as f:
         for line in f:
@@ -20,7 +25,9 @@ def load_iocs(path):
                 iocs.add(val)
     return iocs
 
-def match_iocs(row, ioc_set):
+def match_iocs(row: dict, ioc_set: set[str]) -> list[str]:
+    """Return a list of fields in ``row`` that matched the IOC set."""
+
     matched = []
     for k, v in row.items():
         if v is None:
@@ -35,7 +42,8 @@ def match_iocs(row, ioc_set):
                 matched.append(k)
     return matched
 
-def main():
+def main() -> None:
+    """Entry point for the ``execcheck`` command."""
     parser = argparse.ArgumentParser(description="ExecCheck with IOC support")
     parser.add_argument("--db", required=True)
     parser.add_argument("--config", required=True)

--- a/execcheck/config.py
+++ b/execcheck/config.py
@@ -1,13 +1,7 @@
-from pydantic import BaseModel, Field
-from typing import Optional
+"""Configuration dataclasses and loader for ExecCheck."""
 
-try:
-    import yaml
-except ImportError as exc:
-    raise ImportError(
-        "PyYAML is required for loading configuration files. "
-        "Install it with 'pip install pyyaml'."
-    ) from exc
+from pydantic import BaseModel
+from typing import Optional
 
 class ScoringWeights(BaseModel):
     unsigned: int
@@ -32,6 +26,15 @@ class Config(BaseModel):
     output: OutputConfig
 
 def load_config(path: str) -> Config:
+    """Load a YAML configuration file into a :class:`Config` object."""
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError(
+            "PyYAML is required for loading configuration files. "
+            "Install it with 'pip install pyyaml'."
+        ) from exc
+
     with open(path, "r") as f:
         raw = yaml.safe_load(f)
     return Config(**raw)

--- a/execcheck/correlator.py
+++ b/execcheck/correlator.py
@@ -1,6 +1,11 @@
+"""Correlation helpers for scan and provenance tables."""
+
 import sqlite3
 
-def correlate_exec_data(db_path):
+
+def correlate_exec_data(db_path: str) -> tuple[dict, dict]:
+    """Return scan and provenance data indexed by cdhash."""
+
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
 

--- a/execcheck/formatter.py
+++ b/execcheck/formatter.py
@@ -1,3 +1,5 @@
+"""Output helpers for printing ExecCheck results."""
+
 import json
 import csv
 import re
@@ -6,7 +8,7 @@ from rich.table import Table
 from rich.console import Console
 from rich import box
 
-# Columns shown in table output (terminal only)
+# Columns shown when rendering a table in the terminal
 column_order = [
     'risk_score',
     'score_trace',
@@ -15,15 +17,18 @@ column_order = [
     'origin_url',
 ]
 
-def is_styled_rich(val):
-    """Check if a string already includes rich formatting."""
+def is_styled_rich(val: str) -> bool:
+    """Return ``True`` if ``val`` already contains Rich markup."""
     return isinstance(val, str) and re.search(r"\[[a-zA-Z_]+\]", val)
 
-def truncate(val, width=50):
+def truncate(val: str, width: int = 50) -> str:
+    """Trim long values for table display."""
     val = str(val)
-    return val if len(val) <= width else val[:width - 3] + "..."
+    return val if len(val) <= width else val[: width - 3] + "..."
 
-def output_table(data, config=None):
+def output_table(data: list[dict], config: dict | None = None) -> None:
+    """Render records as a color-coded table using Rich."""
+
     if not data:
         print("No data to display.")
         return
@@ -81,16 +86,19 @@ def output_table(data, config=None):
     console.print(table)
 
 
-def output_json(data, path):
+def output_json(data: list[dict], path: str) -> None:
+    """Write results to ``path`` in JSON format."""
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
 
-def output_ndjson(data, path):
+def output_ndjson(data: list[dict], path: str) -> None:
+    """Write newline-delimited JSON to ``path``."""
     with open(path, "w", encoding="utf-8") as f:
         for row in data:
             f.write(json.dumps(row, separators=(",", ":")) + "\n")
 
-def output_csv(data, path):
+def output_csv(data: list[dict], path: str) -> None:
+    """Save results as a CSV file."""
     if not data:
         print("No data to write.")
         return

--- a/execcheck/init_config.py
+++ b/execcheck/init_config.py
@@ -1,4 +1,9 @@
-def write_default_config():
+"""Utility for generating a sample configuration file."""
+
+
+def write_default_config() -> None:
+    """Write ``sample_config.yaml`` to the current directory."""
+
     sample = """# Default ExecCheck config
 vt_api_key: "YOUR_API_KEY"
 scoring:

--- a/execcheck/parser.py
+++ b/execcheck/parser.py
@@ -1,6 +1,11 @@
+"""Low-level parser for the executable_measurements_v2 table."""
+
 import sqlite3
 
-def parse_exec_policy(db_path):
+
+def parse_exec_policy(db_path: str) -> list[dict]:
+    """Parse the ExecPolicy database and return raw measurement rows."""
+
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
 

--- a/execcheck/scorer.py
+++ b/execcheck/scorer.py
@@ -1,4 +1,8 @@
-def score_entry(entry, config):
+"""Risk scoring rules for ExecCheck entries."""
+
+
+def score_entry(entry: dict, config) -> tuple[int, list[str]]:
+    """Calculate a risk score and trace for a single record."""
     score = 0
     trace = []
 

--- a/execcheck/translate.py
+++ b/execcheck/translate.py
@@ -1,4 +1,8 @@
-def translate_malware_result(val):
+"""Utility functions to translate numeric codes into human labels."""
+
+
+def translate_malware_result(val: int) -> str:
+    """Return a human readable label for a malware result code."""
     mapping = {
         0: "No matching policy",
         1: "Signed by Apple",
@@ -13,7 +17,8 @@ def translate_malware_result(val):
     }
     return mapping.get(val, "Unknown")
 
-def translate_policy_match(val):
+def translate_policy_match(val: int) -> str:
+    """Return a label for a policy match value."""
     mapping = {
         0: "No Match",
         1: "Allow",
@@ -26,7 +31,8 @@ def translate_policy_match(val):
     }
     return mapping.get(val, "Unmapped")
 
-def decode_flags(flag_value):
+def decode_flags(flag_value: int | None) -> list[str] | str:
+    """Decode bitmask ``flag_value`` into a list of flag names."""
     if flag_value is None:
         return "missing"
     if flag_value == 0:

--- a/execcheck/utils/time.py
+++ b/execcheck/utils/time.py
@@ -1,7 +1,11 @@
+"""Utility helpers for working with timestamps."""
+
 from datetime import datetime
 
-def to_iso8601(ts):
+def to_iso8601(ts: int | float | None) -> str:
+    """Convert a UNIX timestamp to an ISO-8601 string."""
+
     try:
         return datetime.utcfromtimestamp(ts).isoformat() + "Z"
-    except:
+    except Exception:
         return "Invalid"

--- a/execcheck/vt.py
+++ b/execcheck/vt.py
@@ -1,7 +1,11 @@
+"""Simple VirusTotal lookups for hash enrichment."""
+
 import time
 import requests
 
-def query_vt(hash_list, api_key):
+def query_vt(hash_list: list[str], api_key: str) -> dict:
+    """Return VirusTotal results for each hash in ``hash_list``."""
+
     headers = {"x-apikey": api_key}
     results = {}
     for h in hash_list:

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,3 +1,28 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from execcheck.scorer import score_entry
+from execcheck.config import Config, ScoringWeights, Whitelist, OutputConfig
+
+
+def make_config():
+    """Create a minimal configuration object for tests."""
+    return Config(
+        vt_api_key=None,
+        scoring=ScoringWeights(
+            unsigned=5,
+            missing_team_id=3,
+            override_blocked=7,
+            vt_malicious=10,
+            custom_flag_mask={0x2000: 4, 0x800: 2},
+        ),
+        whitelist=Whitelist(hashes=[], team_ids=[], paths=[]),
+        output=OutputConfig(min_score=5, filters={"team_id_missing": True, "blocked": True}),
+    )
+
+
 def test_score_entry_override_blocked():
     cfg = make_config()
     entry = {


### PR DESCRIPTION
## Summary
- refactor config loading to import YAML lazily
- add helpful docstrings across modules
- clean up construction comments
- supply tests with sample config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6c5244a88327bd752efe3a13d98d